### PR TITLE
Mejorar la plantilla del formulario del carrito

### DIFF
--- a/src/cart.js
+++ b/src/cart.js
@@ -1,18 +1,18 @@
 // DEBE contener las funcionalidades del carrito de compras.
 import { products } from "../assets/data/data.js";
 
-let botonCarrito = document.getElementById('cart');
-let contenedorCarrito = document.getElementById('cart-container');
+let $botonCarrito = document.getElementById('cart');
+let $contenedorCarrito = document.getElementById('cart-container');
 
 function conmutarCarrito (){
-      if (contenedorCarrito.style.display === "none" || contenedorCarrito.style.display === "" ) {
-      contenedorCarrito.style.display = "block"
+      if ($contenedorCarrito.style.display === "none" || $contenedorCarrito.style.display === "" ) {
+      $contenedorCarrito.style.display = "block"
      } else {
-      contenedorCarrito.style.display = "none";
+      $contenedorCarrito.style.display = "none";
      }
 }
 
-botonCarrito.addEventListener('click', conmutarCarrito);
+$botonCarrito.addEventListener('click', conmutarCarrito);
 
 // Añade pedidos de productos al carrito de compras.
 
@@ -20,11 +20,20 @@ function rellenarPlantillaProductoEnCarrito(producto){
       let $contenedorProductosEnCarrito = document.getElementById("cart-products");
       let $plantillaProductoEnCarrito = $contenedorProductosEnCarrito.getElementsByClassName("cart-container")[0];
       let $textContainer = $plantillaProductoEnCarrito.getElementsByClassName("text-container")[0];
-      let $nombreProducto = $textContainer.getElementsByTagName("h3")[0];
-      let $precioProducto = $textContainer.getElementsByTagName("h5")[0];
 
-      $nombreProducto.innerText = producto.name;
-      $precioProducto.innerText = producto.price.toFixed(2) + ' €';
+      $contenedorCarrito.style.display = "block"
+
+      $plantillaProductoEnCarrito.innerHTML = `
+            <button class="close-button"><img src="./assets/img/close.svg" alt="close"></button>
+            <div class="text-container">
+                  <h3>${producto.name}</h3>
+                  <h5>${producto.price.toFixed(2)} €</h5>
+            </div>
+            <div class="quantity-container" id="quantity">
+                  <button>+</button>
+                  <p class="quantity">1</p>
+                  <button>-</button>
+            </div>`
 }
 
 function buscarProductoPorId(id) {


### PR DESCRIPTION
Se ha mejorado la plantilla del carrito para ayudar en la siguiente tarea a replicar las tarjetas de producto con mas facilidad.

Mejora de UX: ahora al hacer click en Añadir producto, se abre el carrito si estaba cerrado.